### PR TITLE
Remove redundant installation target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Install Dependencies
         run: |
-          pip -q install poetry pytz pre-commit
+          pip -q install poetry pre-commit
           poetry install
 
       - name: Pre-commit Checks


### PR DESCRIPTION
It appears `poetry` includes `pytz` as a dependency, so it does not need to be included in the CI setup.

This was found when exercising `poetry` with PR 32.

References:
* https://github.com/casework/CASE-Mapping-Python/pull/32