### PR TITLE
Add type annotations

### DIFF
--- a/case_mapping/directory.py
+++ b/case_mapping/directory.py
@@ -1,8 +1,9 @@
+from .base import FacetEntity
 from .case import *
 from .uco import *
 
-submodules = [v for k, v in globals().items() if k[:2] != "__"]
+submodules = [v for k, v in globals().items() if k[:2] != "__" and k != "FacetEntity"]
 
-directory = dict()
+directory: dict[str, type[FacetEntity]] = dict()
 for submodule in submodules:
     directory |= submodule.directory

--- a/example.py
+++ b/example.py
@@ -2,7 +2,7 @@ from datetime import datetime, timedelta, timezone
 
 import cdo_local_uuid
 
-from case_mapping import case, uco
+from case_mapping import base, case, uco
 
 # This is part of enabling non-random UUIDs for the demonstration
 # output. The other part is handled at call time, and can be seen in
@@ -28,7 +28,7 @@ def _next_timestamp() -> datetime:
 
 # Generate a case bundle and list to hold investigation items
 bundle = uco.core.Bundle(description="An Example Case File")
-investigation_items = []
+investigation_items: list[base.FacetEntity] = []
 
 ###################################
 # An item to be added to the case #


### PR DESCRIPTION
With these annotations, the following command (with the package `types-pytz` also installed) reports no issues:

    mypy case_mapping example.py tests

Adding type review to unit testing is left for a future patch series.

References:
* https://docs.python.org/3/library/typing.html#the-type-of-class-objects

Disclaimer:
Participation by NIST in the creation of the documentation of mentioned software is not intended to imply a recommendation or endorsement by the National Institute of Standards and Technology, nor is it intended to imply that any specific software is necessarily the best available for the purpose.