### PR TITLE
Fix #6 issue, changing FacetCall, FacetaAccount and FacetPhoneAccount classes

### DIFF
--- a/case.jsonld
+++ b/case.jsonld
@@ -891,12 +891,12 @@
         },
         {
             "@id": "kb:977f4c07-40f2-52b0-8caa-a666b09dd288",
-            "@type": "uco-observable:ObservableObject",
+            "@type": "uco-identity:Organization",
             "uco-core:hasFacet": [
                 {
                     "@id": "kb:b8c4023f-3906-53fc-9709-d84b7752a7fa",
-                    "@type": "uco-observable:ApplicationFacet",
-                    "uco-core:name": "Native"
+                    "@type": "uco-identity:SimpleNameFacet",
+                    "uco-identity:givenName": "Vodafone"
                 }
             ]
         },
@@ -906,6 +906,63 @@
             "uco-core:hasFacet": [
                 {
                     "@id": "kb:27563ba2-9e0f-5974-bfbc-1fecea6e112f",
+                    "@type": "uco-observable:AccountFacet",
+                    "uco-observable:isActive": {
+                        "@type": "xsd:boolean",
+                        "@value": true
+                    },
+                    "uco-observable:accountIdentifier": "Magdalena Android 16",
+                    "uco-observable:accountIssuer": {
+                        "@id": "kb:977f4c07-40f2-52b0-8caa-a666b09dd288"
+                    }
+                },
+                {
+                    "@id": "kb:0508913f-0d16-5243-aafd-cd449c96b7b3",
+                    "@type": "uco-observable:PhoneAccountFacet",
+                    "uco-observable:phoneNumber": "+393283633741"
+                }
+            ]
+        },
+        {
+            "@id": "kb:ed9883e5-abec-5c51-a6c4-981b3be9d1a5",
+            "@type": "uco-observable:ObservableObject",
+            "uco-core:hasFacet": [
+                {
+                    "@id": "kb:0ecef3a5-be49-5682-b690-c68f01fad85c",
+                    "@type": "uco-observable:AccountFacet",
+                    "uco-observable:isActive": {
+                        "@type": "xsd:boolean",
+                        "@value": true
+                    },
+                    "uco-observable:accountIdentifier": "Polly iPhone 12",
+                    "uco-observable:accountIssuer": {
+                        "@id": "kb:977f4c07-40f2-52b0-8caa-a666b09dd288"
+                    }
+                },
+                {
+                    "@id": "kb:f4f66fbb-dfdd-5a98-8371-14a79e2b629c",
+                    "@type": "uco-observable:PhoneAccountFacet",
+                    "uco-observable:phoneNumber": "+393389408011"
+                }
+            ]
+        },
+        {
+            "@id": "kb:eb315866-b333-5702-91bd-7faf00c94e13",
+            "@type": "uco-observable:ObservableObject",
+            "uco-core:hasFacet": [
+                {
+                    "@id": "kb:1793789b-f076-5a3a-b826-a3e29507dadd",
+                    "@type": "uco-observable:ApplicationFacet",
+                    "uco-core:name": "Native"
+                }
+            ]
+        },
+        {
+            "@id": "kb:6dcb74d4-3c61-5c00-8451-c652f3be0be0",
+            "@type": "uco-observable:ObservableObject",
+            "uco-core:hasFacet": [
+                {
+                    "@id": "kb:16f544c7-2319-5319-bf9e-16b061592e0d",
                     "@type": "uco-observable:CallFacet",
                     "uco-observable:callType": "incoming",
                     "uco-observable:startTime": {
@@ -921,14 +978,22 @@
                         "@value": "138"
                     },
                     "uco-observable:application": {
-                        "@id": "kb:977f4c07-40f2-52b0-8caa-a666b09dd288"
+                        "@id": "kb:eb315866-b333-5702-91bd-7faf00c94e13"
                     },
                     "uco-observable:from": {
                         "@id": "kb:73c1b444-4b3a-59b3-820d-76a46ddf0b87"
                     },
                     "uco-observable:to": {
                         "@id": "kb:edaa0df3-b8b8-5fe4-88f8-a5b831e7c59e"
-                    }
+                    },
+                    "uco-observable:participant": [
+                        {
+                            "@id": "kb:986ae934-bb6e-57de-bda1-6b777b50371b"
+                        },
+                        {
+                            "@id": "kb:ed9883e5-abec-5c51-a6c4-981b3be9d1a5"
+                        }
+                    ]
                 }
             ]
         }

--- a/case.jsonld
+++ b/case.jsonld
@@ -820,6 +820,117 @@
                     }
                 }
             ]
+        },
+        {
+            "@id": "kb:900182e5-6098-575c-baec-12c9db246c0d",
+            "@type": "uco-identity:Organization",
+            "uco-core:hasFacet": [
+                {
+                    "@id": "kb:dc1b4415-1284-57ea-b7b9-b75675e7c57c",
+                    "@type": "uco-identity:SimpleNameFacet",
+                    "uco-identity:givenName": "Orange"
+                }
+            ]
+        },
+        {
+            "@id": "kb:73c1b444-4b3a-59b3-820d-76a46ddf0b87",
+            "@type": "uco-observable:ObservableObject",
+            "uco-core:hasFacet": [
+                {
+                    "@id": "kb:508507f8-21aa-51a6-b7bc-0c0545cd6afe",
+                    "@type": "uco-observable:AccountFacet",
+                    "uco-observable:isActive": {
+                        "@type": "xsd:boolean",
+                        "@value": true
+                    },
+                    "uco-observable:accountIdentifier": "Jesse iPhone 8",
+                    "uco-observable:accountIssuer": {
+                        "@id": "kb:900182e5-6098-575c-baec-12c9db246c0d"
+                    }
+                },
+                {
+                    "@id": "kb:750214a2-9feb-54f3-b6d5-ee0f8f1702ef",
+                    "@type": "uco-observable:PhoneAccountFacet",
+                    "uco-observable:phoneNumber": "+19821764400"
+                }
+            ]
+        },
+        {
+            "@id": "kb:fe5a9500-ad81-5d13-85c7-17765ed7d20f",
+            "@type": "uco-identity:Organization",
+            "uco-core:hasFacet": [
+                {
+                    "@id": "kb:1efa0b9c-b315-5030-80ec-dcf6307b3b46",
+                    "@type": "uco-identity:SimpleNameFacet",
+                    "uco-identity:givenName": "Telenor"
+                }
+            ]
+        },
+        {
+            "@id": "kb:edaa0df3-b8b8-5fe4-88f8-a5b831e7c59e",
+            "@type": "uco-observable:ObservableObject",
+            "uco-core:hasFacet": [
+                {
+                    "@id": "kb:20a9bd8b-492e-5b9f-bf8a-1f4087b95fb0",
+                    "@type": "uco-observable:AccountFacet",
+                    "uco-observable:isActive": {
+                        "@type": "xsd:boolean",
+                        "@value": true
+                    },
+                    "uco-observable:accountIdentifier": "Walter iPhone 6",
+                    "uco-observable:accountIssuer": {
+                        "@id": "kb:fe5a9500-ad81-5d13-85c7-17765ed7d20f"
+                    }
+                },
+                {
+                    "@id": "kb:037fe389-9899-55c5-b987-6956eca19c68",
+                    "@type": "uco-observable:PhoneAccountFacet",
+                    "uco-observable:phoneNumber": "+19732941683"
+                }
+            ]
+        },
+        {
+            "@id": "kb:977f4c07-40f2-52b0-8caa-a666b09dd288",
+            "@type": "uco-observable:ObservableObject",
+            "uco-core:hasFacet": [
+                {
+                    "@id": "kb:b8c4023f-3906-53fc-9709-d84b7752a7fa",
+                    "@type": "uco-observable:ApplicationFacet",
+                    "uco-core:name": "Native"
+                }
+            ]
+        },
+        {
+            "@id": "kb:986ae934-bb6e-57de-bda1-6b777b50371b",
+            "@type": "uco-observable:ObservableObject",
+            "uco-core:hasFacet": [
+                {
+                    "@id": "kb:27563ba2-9e0f-5974-bfbc-1fecea6e112f",
+                    "@type": "uco-observable:CallFacet",
+                    "uco-observable:callType": "incoming",
+                    "uco-observable:startTime": {
+                        "@type": "xsd:dateTime",
+                        "@value": "2024-04-19T21:38:19+00:00"
+                    },
+                    "uco-observable:endTime": {
+                        "@type": "xsd:dateTime",
+                        "@value": "2024-04-19T21:40:37+00:00"
+                    },
+                    "uco-observable:duration": {
+                        "@type": "xsd:integer",
+                        "@value": "138"
+                    },
+                    "uco-observable:application": {
+                        "@id": "kb:977f4c07-40f2-52b0-8caa-a666b09dd288"
+                    },
+                    "uco-observable:from": {
+                        "@id": "kb:73c1b444-4b3a-59b3-820d-76a46ddf0b87"
+                    },
+                    "uco-observable:to": {
+                        "@id": "kb:edaa0df3-b8b8-5fe4-88f8-a5b831e7c59e"
+                    }
+                }
+            ]
         }
     ]
 }

--- a/case_mapping/uco/observable.py
+++ b/case_mapping/uco/observable.py
@@ -219,6 +219,10 @@ class FacetAccount(FacetEntity):
         self._str_vars(
             **{
                 "uco-observable:accountIdentifier": identifier,
+            }
+        )
+        self._node_reference_vars(
+            **{
                 "uco-observable:accountIssuer": issuer_id,
             }
         )
@@ -662,16 +666,18 @@ class FacetRasterPicture(FacetEntity):
 class FacetCall(FacetEntity):
     def __init__(
         self,
+        application=None,
         call_type=None,
+        call_duration=None,
         start_time=None,
         end_time=None,
-        application=None,
+        call_participant=None,
         call_from=None,
         call_to=None,
-        call_duration=None,
-        allocation_status=None,
     ):
         """
+        This CASEObject represents a call facet, a grouping of characteristics unique to a
+        connection as part of a realtime cyber communication between one or more parties.
         :param call_type: incoming outgoing etc
         :param start_time: the time at which the device registered the call as starting
         :param end_time: the time at which the device registered the call as ending
@@ -679,6 +685,7 @@ class FacetCall(FacetEntity):
         :param call_from: ObservableObject with person/caller facet-info
         :param call_to: ObservableObject with person/caller facet-info
         :param call_duration: how long the call was registedred on the device as lasting in minutes (E.G. 60)
+        :param call_participant: ObservableObject with the person who joined the cal through their application account
         :param allocation_status: The allocation status of the record of the call i.e intact for records that are
         present on the device
         """
@@ -687,7 +694,6 @@ class FacetCall(FacetEntity):
         self._str_vars(
             **{
                 "uco-observable:callType": call_type,
-                "uco-observable:allocationStatus": allocation_status,
             }
         )
         self._datetime_vars(
@@ -702,23 +708,21 @@ class FacetCall(FacetEntity):
                 "uco-observable:application": application,
                 "uco-observable:from": call_from,
                 "uco-observable:to": call_to,
+                "uco-observable:participant": call_participant,
             }
         )
 
 
 class FacetPhoneAccount(FacetEntity):
-    def __init__(self, phone_number=None, display_name=None):
+    def __init__(self, phone_number=None):
         """
-
         :param phone_number: The number for this account (e.g., "+16503889249")
-        :param display_name: The name of this account/user (e.g., "Bill Bryson")
         """
         super().__init__()
         self["@type"] = "uco-observable:PhoneAccountFacet"
         self._str_vars(
             **{
                 "uco-observable:phoneNumber": phone_number,
-                "uco-observable:displayName": display_name,
             }
         )
 

--- a/case_mapping/uco/observable.py
+++ b/case_mapping/uco/observable.py
@@ -685,7 +685,7 @@ class FacetCall(FacetEntity):
         :param call_from: ObservableObject with person/caller facet-info
         :param call_to: ObservableObject with person/caller facet-info
         :param call_duration: how long the call was registedred on the device as lasting in minutes (E.G. 60)
-        :param call_participant: ObservableObject with the person who joined the cal through their application account
+        :param call_participant: ObservableObject(s) with the account(s) that joined the call
         :param allocation_status: The allocation status of the record of the call i.e intact for records that are
         present on the device
         """

--- a/example.py
+++ b/example.py
@@ -415,6 +415,28 @@ phone_account_facet_2 = uco.observable.FacetPhoneAccount(phone_number="+19732941
 account_object_2.append_facets(account_facet_2, phone_account_facet_2)
 bundle.append_to_uco_object(account_object_2)
 
+identity_organisation_3 = uco.identity.Organization()
+simple_name_facet_3 = uco.identity.FacetSimpleName(given_name="Vodafone")
+identity_organisation_3.append_facets(simple_name_facet_3)
+bundle.append_to_uco_object(identity_organisation_3)
+
+account_object_3 = uco.observable.ObservableObject()
+account_facet_3 = uco.observable.FacetAccount(
+    identifier="Magdalena Android 16", issuer_id=identity_organisation_3
+)
+
+phone_account_facet_3 = uco.observable.FacetPhoneAccount(phone_number="+393283633741")
+account_object_3.append_facets(account_facet_3, phone_account_facet_3)
+bundle.append_to_uco_object(account_object_3)
+
+account_object_4 = uco.observable.ObservableObject()
+account_facet_4 = uco.observable.FacetAccount(
+    identifier="Polly iPhone 12", issuer_id=identity_organisation_3
+)
+phone_account_facet_4 = uco.observable.FacetPhoneAccount(phone_number="+393389408011")
+account_object_4.append_facets(account_facet_4, phone_account_facet_4)
+bundle.append_to_uco_object(account_object_4)
+
 app_call_object = uco.observable.ObservableObject()
 app_call_facet = uco.observable.FacetApplication(app_name="Native")
 app_call_object.append_facets(app_call_facet)
@@ -432,6 +454,7 @@ call_facet = uco.observable.FacetCall(
     end_time=call_end_time,
     call_from=account_object_1,
     call_to=account_object_2,
+    call_participant=[account_object_3, account_object_4],
 )
 call_object.append_facets(call_facet)
 bundle.append_to_uco_object(call_object)

--- a/example.py
+++ b/example.py
@@ -218,9 +218,8 @@ url_history_facet = uco.observable.FacetUrlHistory(
 url_history_entry_object.append_facets(url_history_facet)
 bundle.append_to_uco_object(url_history_entry_object)
 
-
 ############################
-#  Adding an SMS Account   #
+# Adding an SMS Account    #
 ############################
 phone_account_object = uco.observable.ObservableObject()
 phone_account1 = uco.observable.FacetPhoneAccount(phone_number="123456")
@@ -233,7 +232,7 @@ phone_account_object2.append_facets(phone_account2)
 bundle.append_to_uco_object(phone_account_object2)
 
 ############################
-#  Adding an SMS Message   #
+# Adding an SMS Message    #
 ############################
 cyber_item4 = uco.observable.ObservableObject()
 application_cyber_item = uco.observable.ObservableObject()
@@ -384,6 +383,58 @@ social_activity_facet = drafting.entities.FacetSocialMediaActivity(
 
 social_activity_object.append_facets(social_activity_facet)
 bundle.append_to_uco_object(social_activity_object)
+
+##################
+# Adding a Call  #
+##################
+identity_organisation_1 = uco.identity.Organization()
+simple_name_facet_1 = uco.identity.FacetSimpleName(given_name="Orange")
+identity_organisation_1.append_facets(simple_name_facet_1)
+
+bundle.append_to_uco_object(identity_organisation_1)
+
+account_object_1 = uco.observable.ObservableObject()
+account_facet_1 = uco.observable.FacetAccount(
+    identifier="Jesse iPhone 8", issuer_id=identity_organisation_1
+)
+phone_account_facet_1 = uco.observable.FacetPhoneAccount(phone_number="+19821764400")
+account_object_1.append_facets(account_facet_1, phone_account_facet_1)
+
+bundle.append_to_uco_object(account_object_1)
+
+identity_organisation_2 = uco.identity.Organization()
+simple_name_facet_2 = uco.identity.FacetSimpleName(given_name="Telenor")
+identity_organisation_2.append_facets(simple_name_facet_2)
+bundle.append_to_uco_object(identity_organisation_2)
+
+account_object_2 = uco.observable.ObservableObject()
+account_facet_2 = uco.observable.FacetAccount(
+    identifier="Walter iPhone 6", issuer_id=identity_organisation_2
+)
+phone_account_facet_2 = uco.observable.FacetPhoneAccount(phone_number="+19732941683")
+account_object_2.append_facets(account_facet_2, phone_account_facet_2)
+bundle.append_to_uco_object(account_object_2)
+
+app_call_object = uco.observable.ObservableObject()
+app_call_facet = uco.observable.FacetApplication(app_name="Native")
+app_call_object.append_facets(app_call_facet)
+bundle.append_to_uco_object(app_call_object)
+
+call_start_time = datetime.strptime("2024-04-19T21:38:19", "%Y-%m-%dT%H:%M:%S")
+call_end_time = datetime.strptime("2024-04-19T21:40:37", "%Y-%m-%dT%H:%M:%S")
+call_object = uco.observable.ObservableObject()
+
+call_facet = uco.observable.FacetCall(
+    application=app_call_object,
+    call_type="incoming",
+    call_duration=138,
+    start_time=call_start_time,
+    end_time=call_end_time,
+    call_from=account_object_1,
+    call_to=account_object_2,
+)
+call_object.append_facets(call_facet)
+bundle.append_to_uco_object(call_object)
 
 ##################
 # Print the case #


### PR DESCRIPTION
I add the generation of a CallFacet to the example.py. Changes include:

- FacetCall: added observable:participant, deleted allocationStatus (it would be useful to add a property indicating how the Artifact has been extracted: interpreted or carved)
- FacetAccount: the property accountIssuer is now an ObservableObject type not a string 
- FacetPhoneAccount: deleted the displayName property