### PR TITLE
Fix #8 issue, changing ProvenanceRecord

### DIFF
--- a/case.jsonld
+++ b/case.jsonld
@@ -1038,6 +1038,19 @@
                     ]
                 }
             ]
+        },
+        {
+            "@id": "kb:fd27eb1a-bd72-5ecc-b9eb-79a1001ec3a8",
+            "@type": "case-investigation:ProvenanceRecord",
+            "case-investigation:exhibitNumber": "CASE_X_camera_nikon_D750_and_sd_001",
+            "uco-core:object": [
+                {
+                    "@id": "kb:1ccd06e1-1a39-53c2-8e70-86ad7c48ec5c"
+                },
+                {
+                    "@id": "kb:ab4cd39a-dea8-558b-a49e-4aedd9aff7f1"
+                }
+            ]
         }
     ]
 }

--- a/case_mapping/case/investigation.py
+++ b/case_mapping/case/investigation.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from typing import Any, Dict, List, Optional, Union
 
 from pytz import timezone
 
@@ -65,10 +66,14 @@ class CaseInvestigation(ObjectEntity):
 
 
 class ProvenanceRecord(ObjectEntity):
-    def __init__(self, exhibit_number=None, uco_core_objects=None):
+    def __init__(
+        self,
+        exhibit_number: Optional[str] = None,
+        uco_core_objects: Union[None, Dict, List[Dict]] = None,
+    ):
         super().__init__()
         self["@type"] = "case-investigation:ProvenanceRecord"
-        self._int_vars(**{"case-investigation:exhibitNumber": exhibit_number})
+        self._str_vars(**{"case-investigation:exhibitNumber": exhibit_number})
         self._node_reference_vars(**{"uco-core:object": uco_core_objects})
 
 

--- a/case_mapping/case/investigation.py
+++ b/case_mapping/case/investigation.py
@@ -69,7 +69,7 @@ class ProvenanceRecord(ObjectEntity):
     def __init__(
         self,
         exhibit_number: Optional[str] = None,
-        uco_core_objects: Union[None, Dict, List[Dict]] = None,
+        uco_core_objects: Union[None, ObjectEntity, List[ObjectEntity]] = None,
     ):
         super().__init__()
         self["@type"] = "case-investigation:ProvenanceRecord"

--- a/example.py
+++ b/example.py
@@ -33,7 +33,7 @@ investigation_items: list[base.FacetEntity] = []
 ############################################
 # A DeviceFacet and a OperatingSystemFacet #
 ############################################
-cyber_item1 = uco.observable.ObservableObject()
+device_camera = uco.observable.ObservableObject()
 manufacturer_nikon = uco.identity.Organization(name="Nikon")
 bundle.append_to_uco_object(manufacturer_nikon)
 device1 = uco.observable.FacetDevice(manufacturer=manufacturer_nikon, model="D750")
@@ -55,14 +55,14 @@ os_facet = uco.observable.FacetOperatingSystem(
     os_environment_variables=os_env_vars,
 )
 
-cyber_item1.append_facets(device1, os_facet)
-bundle.append_to_uco_object(cyber_item1)
+device_camera.append_facets(device1, os_facet)
+bundle.append_to_uco_object(device_camera)
 
 ##################################
 # A file to be added to the case #
 ##################################
-cyber_item2 = uco.observable.ObservableObject()
-investigation_items.append(cyber_item2)
+sd_card = uco.observable.ObservableObject()
+investigation_items.append(sd_card)
 file1 = uco.observable.FacetFile(
     file_system_type="EXT4",
     file_name="IMG_0123.jpg",
@@ -85,8 +85,8 @@ file_raster1 = uco.observable.FacetRasterPicture(
 
 exif = {"Make": "Canon", "Model": "Powershot"}
 file_exif1 = uco.observable.FacetEXIF(**exif)
-cyber_item2.append_facets(file1, file_content1, file_raster1, file_exif1)
-bundle.append_to_uco_object(cyber_item2)
+sd_card.append_facets(file1, file_content1, file_raster1, file_exif1)
+bundle.append_to_uco_object(sd_card)
 
 #######################################
 # An investigative action on a device #
@@ -128,8 +128,8 @@ bundle.append_to_uco_object(inv_act9)
 # Adding a CASE Relationship #
 ##############################
 cyber_rel1 = uco.observable.ObservableRelationship(
-    source=cyber_item1,
-    target=cyber_item2,
+    source=device_camera,
+    target=sd_card,
     kind_of_relationship="Contained_Within",
     directional=True,
 )
@@ -475,6 +475,16 @@ call_facet = uco.observable.FacetCall(
 )
 call_object.append_facets(call_facet)
 bundle.append_to_uco_object(call_object)
+
+###############################
+# Adding a Provenance Record  #
+###############################
+provenance_rec_object = case.investigation.ProvenanceRecord(
+    exhibit_number="CASE_X_camera_nikon_D750_and_sd_001",
+    uco_core_objects=[device_camera, sd_card],
+)
+bundle.append_to_uco_object(provenance_rec_object)
+
 
 ##################
 # Print the case #


### PR DESCRIPTION
In the ProvenanceRecord class definition I defined the uco_core_objects parameter as follows

uco_core_objects: Union[None, Dict, List[Dict]] = None

instead of 

uco_core_objects: Union[None, ObservableObject, List[ObservableObject]] = None

perhaps it can be defined considering that it will contain ObservableObjects?